### PR TITLE
Release for v0.0.1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,46 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+brews:
+  - tap:
+      owner: orangekame3
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-## [v0.0.1](https://github.com/orangekame3/irodori/commits/v0.0.1) - 2023-09-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## [v0.0.1](https://github.com/orangekame3/irodori/commits/v0.0.1) - 2023-09-19


### PR DESCRIPTION
This pull request is for the next release as v0.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->


## New Contributors
* @orangekame3 made their first contribution in https://github.com/orangekame3/irodori/pull/1

**Full Changelog**: https://github.com/orangekame3/irodori/commits/v0.0.1